### PR TITLE
Typo fix

### DIFF
--- a/txredisapi/protocol.py
+++ b/txredisapi/protocol.py
@@ -349,7 +349,7 @@ class RedisProtocol(basic.LineReceiver, policies.TimeoutMixin):
         """
         set a time to live in seconds on a key
         """
-        return self.execute_command("EXPIRE", name, time)
+        return self.execute_command("EXPIRE", key, time)
 
     def persist(self, key):
         """


### PR DESCRIPTION
Hey, I found a really simple typo in protocol.py in the expire() function.
