### PR TITLE
UnicodeDecodeError with non-Unicode data

### DIFF
--- a/txredisapi/protocol.py
+++ b/txredisapi/protocol.py
@@ -220,8 +220,10 @@ class RedisProtocol(basic.LineReceiver, policies.TimeoutMixin):
             try:
                 element = int(data) if data.find('.') == -1 else float(data)
             except (ValueError):
-                element = data
-
+                try:
+                    element = data.decode(self.charset)
+                except UnicodeDecodeError:
+                    element = data
         if self.multi_bulk_length > 0:
             self.handleMultiBulkElement(element)
         else:


### PR DESCRIPTION
Hey there,

Got another bug fix.  We were putting in some non-unicode data, which worked just fine.  However, when we tried to get it back out we'd sometimes get a UnicodeDecodeError, depending on the data.  I've got a fix that will try the decode call, but fallback to just the str if it gets the decode exception.  This seems to have cleared up our issue.

Keith.
