### PR TITLE
Minor edits to make code flake8 clean.

### DIFF
--- a/examples/cyclone_demo.py
+++ b/examples/cyclone_demo.py
@@ -18,7 +18,6 @@
 
 import collections
 import functools
-import os.path
 import sys
 
 import cyclone.web
@@ -62,7 +61,7 @@ class RedisMixin(object):
 
     def subscribe(self, channel):
         if RedisMixin.psconn is None:
-            raise cyclone.web.HTTPError(503) # Service Unavailable
+            raise cyclone.web.HTTPError(503)  # Service Unavailable
 
         if channel not in RedisMixin.channels:
             log.msg("Subscribing entire server to %s" % channel)
@@ -125,7 +124,8 @@ class TextHandler(cyclone.web.RequestHandler, RedisMixin):
         try:
             yield self.dbconn.set(key, value)
         except Exception, e:
-            log.err("Redis failed to set('%s', '%s'): %s" % (key, value, str(e)))
+            r = (key, value, str(e))
+            log.err("Redis failed to set('%s', '%s'): %s" % r)
             raise cyclone.web.HTTPError(503)
 
         self.set_header("Content-Type", "text/plain")

--- a/examples/sharding.py
+++ b/examples/sharding.py
@@ -6,6 +6,7 @@ import txredisapi as redis
 from twisted.internet import defer
 from twisted.internet import reactor
 
+
 @defer.inlineCallbacks
 def main():
     # run two redis servers, one at port 6379 and another in 6380

--- a/examples/subscriber.py
+++ b/examples/subscriber.py
@@ -25,7 +25,6 @@ import txredisapi as redis
 
 from twisted.application import internet
 from twisted.application import service
-from twisted.internet import reactor
 
 
 class myProtocol(redis.SubscriberProtocol):

--- a/examples/twistedweb_server.py
+++ b/examples/twistedweb_server.py
@@ -26,14 +26,18 @@ from twisted.web import server
 from twisted.web import xmlrpc
 from twisted.web.resource import Resource
 
+
 class Root(Resource):
     isLeaf = False
 
+
 class BaseHandler(object):
     isLeaf = True
+
     def __init__(self, db):
         self.db = db
         Resource.__init__(self)
+
 
 class IndexHandler(BaseHandler, Resource):
     def _success(self, value, request, message):

--- a/examples/wordfreq.py
+++ b/examples/wordfreq.py
@@ -7,6 +7,7 @@ import txredisapi as redis
 from twisted.internet import defer
 from twisted.internet import reactor
 
+
 def wordfreq(file):
     try:
         f = open(file, 'r')
@@ -16,14 +17,14 @@ def wordfreq(file):
         print "Exception: %s" % e
         return None
 
-    wf={}
+    wf = {}
     wlist = words.split()
     for b in wlist:
-        a=b.lower()
-        if wf.has_key(a):
-            wf[a]=wf[a]+1
+        a = b.lower()
+        if a in wf:
+            wf[a] = wf[a] + 1
         else:
-           wf[a]=1
+            wf[a] = 1
     return len(wf), wf
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import setuptools
 
 setuptools.setup(

--- a/tests/chash_distribution.py
+++ b/tests/chash_distribution.py
@@ -6,12 +6,12 @@ from collections import defaultdict
 
 if __name__ == "__main__":
     ch = HashRing(["server1", "server2", "server3"])
-    key_history={}
-    node_histogram=defaultdict(lambda: 0)
+    key_history = {}
+    node_histogram = defaultdict(lambda: 0)
     for x in xrange(1000):
-        key_history[x]=ch.get_node("k:%d" % x)
-        s=key_history[x]
-        node_histogram[s]=node_histogram[s]+1
+        key_history[x] = ch.get_node("k:%d" % x)
+        s = key_history[x]
+        node_histogram[s] = node_histogram[s] + 1
     print "server\t\tkeys:"
     for a in node_histogram.keys():
         print "%s:\t%d" % (a, node_histogram[a])

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -17,12 +17,12 @@ import txredisapi as redis
 
 from twisted.internet import base
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.trial import unittest
 
 base.DelayedCall.debug = False
-redis_host="localhost"
-redis_port=6379
+redis_host = "localhost"
+redis_port = 6379
+
 
 class TestConnectionMethods(unittest.TestCase):
     @defer.inlineCallbacks
@@ -33,13 +33,15 @@ class TestConnectionMethods(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_ConnectionDB1(self):
-        db = yield redis.Connection(redis_host, redis_port, dbid=1, reconnect=False)
+        db = yield redis.Connection(redis_host, redis_port, dbid=1,
+                reconnect=False)
         self.assertEqual(isinstance(db, redis.ConnectionHandler), True)
         yield db.disconnect()
 
     @defer.inlineCallbacks
     def test_ConnectionPool(self):
-        db = yield redis.ConnectionPool(redis_host, redis_port, poolsize=2, reconnect=False)
+        db = yield redis.ConnectionPool(redis_host, redis_port, poolsize=2,
+                reconnect=False)
         self.assertEqual(isinstance(db, redis.ConnectionHandler), True)
         yield db.disconnect()
 

--- a/tests/test_hash_ops.py
+++ b/tests/test_hash_ops.py
@@ -16,11 +16,11 @@
 import txredisapi as redis
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.trial import unittest
 
-redis_host="localhost"
-redis_port=6379
+redis_host = "localhost"
+redis_port = 6379
+
 
 class TestRedisHashOperations(unittest.TestCase):
     @defer.inlineCallbacks
@@ -39,7 +39,7 @@ class TestRedisHashOperations(unittest.TestCase):
         t_dict = {}
         t_dict['key1'] = 'uno'
         t_dict['key2'] = 'dos'
-        s = yield db.hmset("txredisapi:HMSetHMGet", t_dict)
+        yield db.hmset("txredisapi:HMSetHMGet", t_dict)
         ks = t_dict.keys()
         ks.reverse()
         vs = t_dict.values()
@@ -55,7 +55,7 @@ class TestRedisHashOperations(unittest.TestCase):
         t_dict = {}
         t_dict['key1'] = 'uno'
         t_dict['key2'] = 'dos'
-        s = yield db.hmset("txredisapi:HKeysHVals", t_dict)
+        yield db.hmset("txredisapi:HKeysHVals", t_dict)
 
         vs_u = [unicode(v) for v in t_dict.values()]
         ks_u = [unicode(k) for k in t_dict.keys()]
@@ -106,7 +106,7 @@ class TestRedisHashOperations(unittest.TestCase):
     def testRedisHGetAll(self):
         db = yield redis.Connection(redis_host, redis_port, reconnect=False)
 
-        d = {u"key1":u"uno", u"key2":u"dos"}
+        d = {u"key1": u"uno", u"key2": u"dos"}
         yield db.hmset("txredisapi:HGetAll", d)
         s = yield db.hgetall("txredisapi:HGetAll")
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -15,11 +15,11 @@
 
 import txredisapi as redis
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.trial import unittest
 
-redis_host="localhost"
-redis_port=6379
+redis_host = "localhost"
+redis_port = 6379
+
 
 class TestRedisConnections(unittest.TestCase):
     @defer.inlineCallbacks
@@ -27,12 +27,13 @@ class TestRedisConnections(unittest.TestCase):
         db = yield redis.Connection(redis_host, redis_port, reconnect=False)
 
         # test set() operation
-        for key, value in (("txredisapi:test1", "foo"), ("txredisapi:test2", "bar")):
+        kvpairs = (("txredisapi:test1", "foo"), ("txredisapi:test2", "bar"))
+        for key, value in kvpairs:
             yield db.set(key, value)
             result = yield db.get(key)
             self.assertEqual(result, value)
 
-        d = {"txredisapi:a":1, "txredisapi:b":2}
+        d = {"txredisapi:a": 1, "txredisapi:b": 2}
         yield db.mset(d)
         values = yield db.mget(d.keys())
         self.assertEqual(values, d.values())

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 
 import txredisapi as redis
-from twisted.internet import defer, reactor
+from twisted.internet import defer
 from twisted.trial import unittest
 
-redis_host="localhost"
-redis_port=6379
+redis_host = "localhost"
+redis_port = 6379
+
 
 class TestRedisConnections(unittest.TestCase):
     @defer.inlineCallbacks

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -18,8 +18,8 @@ from twisted.internet import defer
 from twisted.python.failure import Failure
 from twisted.trial import unittest
 
-redis_host="localhost"
-redis_port=6379
+redis_host = "localhost"
+redis_port = 6379
 
 
 class TestRedisConnections(unittest.TestCase):


### PR DESCRIPTION
Just ran `find . -name "*.py" | xargs flake8` and cleaned up whatever warnings it threw up.
