### PR TITLE
Fixing issue with mget

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -38,4 +38,8 @@ class TestRedisConnections(unittest.TestCase):
         values = yield db.mget(d.keys())
         self.assertEqual(values, d.values())
 
+        keys = ['txredisapi:a', 'txredisapi:notset', 'txredisapi:b']
+        values = yield db.mget(keys)
+        self.assertEqual(values, [1, None, 2])
+
         yield db.disconnect()

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -205,7 +205,11 @@ class RedisProtocol(basic.LineReceiver, policies.TimeoutMixin):
                     if idx == -1:
                         break
                     data_len = int(rest[1:idx], 10)
-                    if len(rest) >= (idx + 5 + data_len):
+                    if data_len == -1:
+                        rest = rest[5:]
+                        self.bulkDataReceived(None)
+                        continue
+                    elif len(rest) >= (idx + 5 + data_len):
                         data_start = idx + 2
                         data_end = data_start + data_len
                         data = rest[data_start: data_end]


### PR DESCRIPTION
I was having issues with txredisapi if a value in the middle of a mget is not set (here's a simple example):

```
from twisted.internet import defer, reactor
import txredisapi

@defer.inlineCallbacks
def main():
    r = yield txredisapi.Connection('127.0.0.1')
    yield r.flushdb()

    yield r.set('key1', 'val1')
    yield r.set('key3', 'val3')

    ret = yield r.mget(['key1', 'key2', 'key3'])

    print 'Got back:'
    for each in ret:
        print repr(each)

if __name__ == '__main__':
    main()
    reactor.run()
```

This should return ['val1', None, 'val3'], but instead it hangs. This pull request fixes that and adds a unit test for this situation as well.
