### PR TITLE
SubscriberProtocol.*subscribe() returns stale deferred

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1331,6 +1331,7 @@ class SubscriberProtocol(RedisProtocol):
             if reply[-3] == u"message":
                 self.messageReceived(None, *reply[-2:])
             else:
+                self.replyQueue.put(reply[-3])
                 self.messageReceived(*reply[-3:])
 
     def subscribe(self, channels):


### PR DESCRIPTION
Deferred returned by these methods was waiting for data to appear in replyQueue which never happened. Fixed this by submitting message type name to replyQueue if the type is anything but 'message'.
