### PR TITLE
make it possible to use watch properly

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1625,6 +1625,7 @@ class ShardedUnixConnectionHandler(ShardedConnectionHandler):
 class RedisFactory(protocol.ReconnectingClientFactory):
     maxDelay = 10
     protocol = RedisProtocol
+    noise = False
 
     def __init__(self, uuid, dbid, poolsize, isLazy=False,
                  handler=ConnectionHandler):


### PR DESCRIPTION
This patch seperates watch and multi commands, making it possible to issue a watch, fetch variables, and then perform the multi block. Making it possible to use the CAS pattern presented in http://redis.io/topics/transactions

The second commit/patch is just reduce the logging output of txredisapi a bit
