### PR TITLE
possibility to set offset=0 in zrangebyscore

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -972,7 +972,7 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
             pieces = [cmd, key, min, max, "WITHSCORES"]
         else:
             pieces = [cmd, key, min, max]
-        if offset and count:
+        if offset is not None and count is not None:
             pieces.extend(("LIMIT", offset, count))
         r = self.execute_command(*pieces)
         if withscores:


### PR DESCRIPTION
Hi!
I think that zrangebyscore('key', offset=0, count=10) should be translated to the valid redis command "ZREVRANGEBYSCORE which '+inf' '-inf' withscores limit 0 3".  Instead it just ignored because of "if offset and count: "  construction.
