### PR TITLE
dealing with some edge cases and documenting the new WATCH functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ But they work pretty good on normal or lazy connections, and connection pools.
 
 NOTE: redis uses the following methods for transactions:
 
+- WATCH: synchronization
 - MULTI: start the transaction
 - EXEC: commit the transaction
 - DISCARD: you got it.
@@ -476,6 +477,55 @@ Example:
     if __name__ == "__main__":
         main().addCallback(lambda ign: reactor.stop())
         reactor.run()
+
+A "COUNTER" example, using WATCH/MULTI:
+
+     #!/usr/bin/env python
+     # coding: utf-8
+          
+     import txredisapi as redis
+          
+     from twisted.internet import defer
+     from twisted.internet import reactor
+          
+          
+     @defer.inlineCallbacks
+     def main():
+         rc = yield redis.ConnectionPool()
+          
+         # Reset keys
+         yield rc.set("a1", 0)
+          
+         # Synchronize and start transaction
+         t = yield rc.watch("a1")
+          
+         # Load previous value
+         a1 = yield t.get("a1")
+          
+         # start the transactional pipeline
+         yield t.multi()
+          
+         # modify and retrieve the new a1 value
+         yield t.set("a1", a1 + 1)
+         yield t.get("a1")
+          
+         print "simulating concurrency, this will abort the transaction"
+         yield rc.set("a1", 2)
+          
+         try:
+             r = yield t.commit()
+             print "commit=", repr(r)
+         except redis.WatchError, e:
+             a1 = yield rc.get("a1")
+             print "transaction has failed."
+             print "current a1 value: ", a1
+          
+         yield rc.disconnect()
+          
+          
+     if __name__ == "__main__":
+         main().addCallback(lambda ign: reactor.stop())
+         reactor.run()
 
 
 Calling ``commit`` will cause it to return a list with the return of all
@@ -544,3 +594,7 @@ Thanks to (in no particular order):
 - Christoph Tavan (@ctavan)
 
   - Idea and test case for nested multi bulk replies, minor command enhancements.
+
+- dgvncsz0f
+
+  - WATCH/UNWATCH commands


### PR DESCRIPTION
This patch deals with the following scenarios, which would ended up
cleaning the inTransaction prematurely:
1. UNWATCH after MULTI
   
   t = multi
   t.unwatch
2. WATCH, MULTI (with keys)
   
   t = watch
   t.multi("foobar")
   t.unwatch

3 . MULTI + WATCH

  t = multi
  t.watch   # this is invalid, but
              will change the _unwatch_cc
              to a function that would clear
              the inTransaction state

I've also dropped a couple more tests, notably testing WATCH with ConnectionPool.
