### PR TITLE
WATCH + MGET (or any bulk command) prevents connection from clearing transaction state

### DIFF
--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -79,3 +79,12 @@ class TestRedisConnections(unittest.TestCase):
         self.assertIsInstance(t, redis.RedisProtocol)
         yield t.set(self._KEYS[1], 'bar')
         yield t.commit().addBoth(self._check_watcherror, shouldError=False)
+
+    @defer.inlineCallbacks
+    def testRedisWithBulkCommands(self):
+        t = yield self.db.watch("foobar")
+        yield t.mget(["foo", "bar"])
+        t = yield t.multi()
+        yield t.commit()
+        self.assertEqual(0, t.transactions)
+        self.assertFalse(t.inTransaction)


### PR DESCRIPTION
The problem:

> conn  = yield conn.watch(key)
> reply = yield conn.mget([1, 2])
> conn  = yield conn.multi()
> yield conn.exec()

This will result in `conn.transactions` negative. The code that clears
the `inTransaction` flag relies that this number is either 0 (zero) or
positive. Thus, afterwards, the connection has been losted, as the
`inTransaction` will never clear up.

This fix relies on the fact that once `MULTI` command has been issued,
all replies are effectively `QUEUED` until redis receives an `EXEC`
command.

> if self.transactions > 0:
>     self.transactions -= len(reply)
