### PR TITLE
Password parameter for Connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,29 +111,29 @@ with absolutely no changes to the logic of your program.
 
 These are all the supported methods for connecting to Redis::
 
-    Connection(host, port, dbid, reconnect)
-    lazyConnection(host, port, dbid, reconnect)
+    Connection(host, port, dbid, password, reconnect)
+    lazyConnection(host, port, dbid, password, reconnect)
 
-    ConnectionPool(host, port, dbid, poolsize, reconnect)
-    lazyConnectionPool(host, port, dbid, poolsize, reconnect)
+    ConnectionPool(host, port, dbid, password, poolsize, reconnect)
+    lazyConnectionPool(host, port, dbid, password, poolsize, reconnect)
 
-    ShardedConnection(hosts, dbid, reconnect)
-    lazyShardedConnection(hosts, dbid, reconnect)
+    ShardedConnection(hosts, dbid, password, reconnect)
+    lazyShardedConnection(hosts, dbid, password, reconnect)
 
-    ShardedConnectionPool(hosts, dbid, poolsize, reconnect)
-    lazyShardedConnectionPool(hosts, dbid, poolsize, reconnect)
+    ShardedConnectionPool(hosts, dbid, password, poolsize, reconnect)
+    lazyShardedConnectionPool(hosts, dbid, password, poolsize, reconnect)
 
-    UnixConnection(path, dbid, reconnect)
-    lazyUnixConnection(path, dbid, reconnect)
+    UnixConnection(path, dbid, password, reconnect)
+    lazyUnixConnection(path, dbid, password, reconnect)
 
-    UnixConnectionPool(unix, dbid, poolsize, reconnect)
-    lazyUnixConnectionPool(unix, dbid, poolsize, reconnect)
+    UnixConnectionPool(unix, dbid, password, poolsize, reconnect)
+    lazyUnixConnectionPool(unix, dbid, password, poolsize, reconnect)
 
-    ShardedUnixConnection(paths, dbid, reconnect)
-    lazyShardedUnixConnection(paths, dbid, reconnect)
+    ShardedUnixConnection(paths, dbid, password, reconnect)
+    lazyShardedUnixConnection(paths, dbid, password, reconnect)
 
-    ShardedUnixConnectionPool(paths, dbid, poolsize, reconnect)
-    lazyShardedUnixConnectionPool(paths, dbid, poolsize, reconnect)
+    ShardedUnixConnectionPool(paths, dbid, password, poolsize, reconnect)
+    lazyShardedUnixConnectionPool(paths, dbid, password, poolsize, reconnect)
 
 
 The arguments are:
@@ -142,6 +142,7 @@ The arguments are:
 - port: port number of the redis server. [default: 6379]
 - path: path of redis server's socket [default: /tmp/redis.sock]
 - dbid: database id of redis server. [default: 0]
+- password: authentication password of redis server. [default: None]
 - poolsize: how many connections to make. [default: 10]
 - reconnect: auto-reconnect if connection is lost. [default: True]
 - hosts (for sharded): list of ``host:port`` pairs. [default: None]
@@ -560,11 +561,6 @@ This is how to authenticate::
 
 If the password does not match, most of the commands will return nothing,
 except for ``get``, which returns ``operation not permitted``.
-
-There's one caveat: whenever authentication is required, the *database id* must
-be manually selected after the ``auth`` command. The ``dbid=N`` argument of
-``Connection()`` must not be defined, or set to ``None``; otherwise, it'll try
-to select *dbid* before authentication, and it will fail.
 
 
 Credits

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import setuptools
 
 setuptools.setup(
     name="txredisapi",
-    version="1.1",
+    version="v1.1.4",
     py_modules=["txredisapi"],
     install_requires=["twisted"],
     author="Alexandre Fiori",

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -215,7 +215,7 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
 
     @defer.inlineCallbacks
     def connectionMade(self):
-        if self.factory.password is not None:
+        if self.factory.password:
             try:
                 response = yield self.auth(self.factory.password)
                 if isinstance(response, ResponseError):
@@ -230,7 +230,7 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
                     log.msg(msg)
                 defer.returnValue(None)
 
-        if self.factory.dbid is not None:
+        if self.factory.dbid:
             try:
                 response = yield self.select(self.factory.dbid)
                 if isinstance(response, ResponseError):

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -851,13 +851,13 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
         """
         return self.execute_command("BRPOPLPUSH", source, destination, timeout)
 
-    def rpoplpush(self, srckey, dstkey, timeout=0):
+    def rpoplpush(self, srckey, dstkey):
         """
         Return and remove (atomically) the last element of the source
         List  stored at srckey and push the same element to the
         destination List stored at dstkey
         """
-        return self.execute_command("RPOPLPUSH", srckey, dstkey, timeout)
+        return self.execute_command("RPOPLPUSH", srckey, dstkey)
 
     def _make_set(self, result):
         if isinstance(result, list):

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -844,20 +844,20 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
         keys.append(timeout)
         return self.execute_command("BRPOP", *keys)
 
-    def brpoplpush(self, source, destination):
+    def brpoplpush(self, source, destination, timeout=0):
         """
         Pop a value from a list, push it to another list and return
         it; or block until one is available.
         """
-        return self.execute_command("BRPOPLPUSH", source, destination)
+        return self.execute_command("BRPOPLPUSH", source, destination, timeout)
 
-    def rpoplpush(self, srckey, dstkey):
+    def rpoplpush(self, srckey, dstkey, timeout=0):
         """
         Return and remove (atomically) the last element of the source
         List  stored at srckey and push the same element to the
         destination List stored at dstkey
         """
-        return self.execute_command("RPOPLPUSH", srckey, dstkey)
+        return self.execute_command("RPOPLPUSH", srckey, dstkey, timeout)
 
     def _make_set(self, result):
         if isinstance(result, list):

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -732,7 +732,7 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
         """
         return self.execute_command("APPEND", key, value)
 
-    def substr(self, key, start, end=-1):
+    def substr(self, key, start, end= -1):
         """
         Return a substring of a larger string
         """
@@ -1038,13 +1038,13 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
             r.addCallback(self._handle_withscores)
         return r
 
-    def zrange(self, key, start=0, end=-1, withscores=False):
+    def zrange(self, key, start=0, end= -1, withscores=False):
         """
         Return a range of elements from the sorted set at key
         """
         return self._zrange(key, start, end, withscores, False)
 
-    def zrevrange(self, key, start=0, end=-1, withscores=False):
+    def zrevrange(self, key, start=0, end= -1, withscores=False):
         """
         Return a range of elements from the sorted set at key,
         exactly like ZRANGE, but the sorted set is ordered in
@@ -1111,7 +1111,7 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
         """
         return self.execute_command("ZSCORE", key, element)
 
-    def zremrangebyrank(self, key, min=0, max=-1):
+    def zremrangebyrank(self, key, min=0, max= -1):
         """
         Remove all the elements with rank >= min and rank <= max from
         the sorted set
@@ -1489,7 +1489,7 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
                                     "KILL").addBoth(self._handle_script_kill)
 
     def script_load(self, script):
-        return self.execute_command("SCRIPT",  "LOAD", script)
+        return self.execute_command("SCRIPT", "LOAD", script)
 
 
 class MonitorProtocol(RedisProtocol):
@@ -1874,7 +1874,7 @@ class SubscriberFactory(RedisFactory):
     protocol = SubscriberProtocol
 
     def __init__(self, isLazy=False, handler=ConnectionHandler):
-        RedisFactory.__init__(self, None, None, 1, isLazy=isLazy,
+        RedisFactory.__init__(self, None, None, None, 1, isLazy=isLazy,
                               handler=handler)
 
 
@@ -1882,7 +1882,7 @@ class MonitorFactory(RedisFactory):
     protocol = MonitorProtocol
 
     def __init__(self, isLazy=False, handler=ConnectionHandler):
-        RedisFactory.__init__(self, None, None, 1, isLazy=isLazy,
+        RedisFactory.__init__(self, None, None, None, 1, isLazy=isLazy,
                               handler=handler)
 
 


### PR DESCRIPTION
We should pass the password when a connection is created.

The old recommended way of using .auth(...) and .select(...) manually does not work when reconnect=True. These settings are not retransmitted when the connection was lost. This pull request should fix that.
