### PR TITLE
Commands with kwargs fail with TypeError instead of ConnectionError when connection is down

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1562,7 +1562,7 @@ class ConnectionHandler(object):
         except Exception, e:
             d = defer.Deferred()
             d.errback(e)
-            return lambda *ign: d
+            return lambda *ign, **kwign: d
 
     def __repr__(self):
         try:


### PR DESCRIPTION
When the connection to Redis server is down, ConnectionHandler replaces proper methods with dummy `lambda`s which accept only positional arguments. If some Redis command is then called with keyword arguments, a confusing traceback is produced:

```
2013-03-30 23:33:05+0400 [HTTPChannel,1,127.0.0.1] Unhandled Error
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/twisted/protocols/basic.py", line 581, in dataReceived
    why = self.lineReceived(line)
  File "/usr/local/lib/python2.7/dist-packages/twisted/web/http.py", line 1611, in lineReceived
    self.allContentReceived()
  File "/usr/local/lib/python2.7/dist-packages/twisted/web/http.py", line 1686, in allContentReceived
    req.requestReceived(command, path, version)
  File "/usr/local/lib/python2.7/dist-packages/twisted/web/http.py", line 790, in requestReceived
    self.process()
--- <exception caught here> ---
  File "/usr/local/lib/python2.7/dist-packages/twisted/web/server.py", line 192, in process
    self.render(resrc)
  File "/usr/local/lib/python2.7/dist-packages/twisted/web/server.py", line 241, in render
    body = resrc.render(self)
  File "/usr/local/lib/python2.7/dist-packages/twisted/web/resource.py", line 250, in render
    return m(request)
  File "twistedweb_server.py", line 59, in render_GET
    self.db.zrangebyscore('foo', count=33, offset=0)
exceptions.TypeError: <lambda>() got an unexpected keyword argument 'count'
```

Attached patch allows this dummy `lambda` to accept keyword arguments, so that a proper error message can be seen in server log:

```
2013-03-30 23:32:08+0400 [HTTPChannel,1,127.0.0.1] Unhandled Error
Traceback (most recent call last):
Failure: txredisapi.ConnectionError: Not connected
```
