### PR TITLE
adding error handling for "multi" command

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1348,7 +1348,13 @@ class RedisProtocol(LineReceiver, policies.TimeoutMixin):
         else:
             d = self.execute_command("MULTI")
         d.addCallback(self._tx_started)
+        d.addErrback(self._multi_errback)
         return d
+
+    def _multi_errback(self, err):
+        self.post_proc = []
+        self.inTransaction = False
+        raise err
 
     def _tx_started(self, response):
         if response != 'OK':


### PR DESCRIPTION
now txredis client hangs up after "multi" command fail.

You can find source code example at issues to reproduce it.
