### PR TITLE
command execution waits to connection establishment

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1,4 +1,4 @@
-# codingr utf-8
+# coding: utf-8
 # Copyright 2009 Alexandre Fiori
 # https://github.com/fiorix/txredisapi
 #
@@ -2033,7 +2033,7 @@ class RedisFactory(protocol.ReconnectingClientFactory):
 
     @defer.inlineCallbacks
     def getConnection(self, put_back=False):
-        if not self.size:
+        if not self.continueTrying and not self.size:
             raise ConnectionError("Not connected")
 
         while True:


### PR DESCRIPTION
When lazyConnectionPool's handler is created and immediately used to execute command while TCP layer is connecting, command execution fails with ConnectionError. This change keeps connection pending until connection is established.
