### PR TITLE
testing code should not explicitly enable logging

### DIFF
--- a/tests/test_pipelining.py
+++ b/tests/test_pipelining.py
@@ -25,7 +25,7 @@ import txredisapi
 
 from tests.mixins import REDIS_HOST, REDIS_PORT
 
-log.startLogging(sys.stdout)
+# log.startLogging(sys.stdout)
 
 
 class InspectableTransport(object):

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -23,7 +23,7 @@ import txredisapi
 
 from tests.mixins import REDIS_HOST, REDIS_PORT
 
-log.startLogging(sys.stdout)
+# log.startLogging(sys.stdout)
 
 
 class TestRedisConnections(unittest.TestCase):


### PR DESCRIPTION
Enabling logs in toplevel code results in side effects of importing module and also makes `trial tests` output clunky