### PR TITLE
Proper reply timeouts handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Release 1.4.6 (UNRELEASED)
+
+### Bugfixes
+
+- replyTimeout connection argument fixed. All query methods except `blpop()`,
+  `brpop()`, `brpoplpush()` now raise `TimeoutError` if reply wasn't received
+  within `replyTimeout` seconds.
+
+---
+
 ## Release 1.4.5 (2017-11-08)
 
 ### Features

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -12,14 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from twisted.internet import base
 from twisted.internet import defer
+from twisted.internet.task import Clock
+from twisted.test.iosim import connectedServerAndClient
 from twisted.trial import unittest
 
 import txredisapi as redis
 
 from tests.mixins import REDIS_HOST, REDIS_PORT
+from tests.test_sentinel import FakeRedisProtocol, FakeRedisFactory
 
 base.DelayedCall.debug = False
 
@@ -74,3 +76,120 @@ class TestConnectionMethods(unittest.TestCase):
         db = yield redis.ShardedConnectionPool(hosts, reconnect=False)
         self.assertEqual(isinstance(db, redis.ShardedConnectionHandler), True)
         yield db.disconnect()
+
+    @defer.inlineCallbacks
+    def test_dbid(self):
+        db1 = yield redis.Connection(REDIS_HOST, REDIS_PORT, reconnect=False, dbid=1)
+        db2 = yield redis.Connection(REDIS_HOST, REDIS_PORT, reconnect=False, dbid=5)
+        self.addCleanup(db1.disconnect)
+        self.addCleanup(db2.disconnect)
+
+        yield db1.set('x', 42)
+        try:
+            value = yield db2.get('x')
+            self.assertIs(value, None)
+        finally:
+            yield db1.delete('x')
+
+
+class SlowServerProtocol(FakeRedisProtocol):
+    def __init__(self, reactor, delay, storage):
+        FakeRedisProtocol.__init__(self)
+        self.callLater = reactor.callLater
+        self.delay = delay
+        self.storage = storage
+        self._delayed_calls = []
+
+    def replyReceived(self, request):
+        if isinstance(request, list):
+            if request[0] == "GET":
+                name = request[1]
+                if name in self.storage:
+                    self.send_reply(self.storage[name])
+            else:
+                self.send_error("Command not supported")
+        else:
+            FakeRedisProtocol.replyReceived(self, request)
+
+    def send_reply(self, reply):
+        self._delayed_calls.append(
+            self.callLater(self.delay, FakeRedisProtocol.send_reply, self, reply)
+        )
+
+    def send_error(self, msg):
+        self._delayed_calls.append(
+            self.callLater(self.delay, FakeRedisProtocol.send_error, self, msg)
+        )
+
+    def connectionLost(self, why):
+        for call in self._delayed_calls:
+            if call.active():
+                call.cancel()
+
+
+class TestTimeouts(unittest.TestCase):
+    def setUp(self):
+        self.clock = Clock()
+
+        old = redis.LineReceiver.callLater
+        redis.LineReceiver.callLater = self.clock.callLater
+
+        def cleanup():
+            redis.LineReceiver.callLater = old
+        self.addCleanup(cleanup)
+
+
+    def _clientAndServer(self, clientTimeout, serverTimeout, initialStorage=None):
+        storage = initialStorage or {}
+        return connectedServerAndClient(
+            lambda: SlowServerProtocol(self.clock, serverTimeout, storage),
+            lambda: redis.RedisProtocol(replyTimeout=clientTimeout)
+        )
+
+    def test_noTimeout(self):
+        client, server, pump = self._clientAndServer(2, 1, {'x': 42})
+
+        result = client.get('x')
+        pump.flush()
+        self.assertFalse(result.called)
+        self.clock.pump([0, 1.1])
+        pump.flush()
+        self.assertEqual(self.successResultOf(result), 42)
+
+        # ensure that idle connection is not closed by timeout
+        self.clock.pump([0, 5])
+        result2 = client.get('x')
+        pump.flush()
+        self.clock.pump([0, 1.1])
+        pump.flush()
+        self.assertEqual(self.successResultOf(result2), 42)
+
+
+    def test_timedOut(self):
+        client, server, pump = self._clientAndServer(0.5, 1, {'x': 42})
+
+        result = client.get('x')
+        pump.flush()
+        self.assertFalse(result.called)
+        self.clock.pump([0, 0.6])
+        pump.flush()
+        self.failureResultOf(result, redis.TimeoutError)
+
+
+    def test_timeoutBreaksConnection(self):
+        """
+        When the call is timed out connection to Redis is closed and all
+        pending queries are interrupted with ConnectionError (because they
+        are not timed out yet themselves)
+        """
+        client, server, pump = self._clientAndServer(0.5, 1, {'x': 42})
+
+        result1 = client.get('x')
+        pump.flush()
+        self.clock.pump([0, 0.3])
+        result2 = client.get('x')
+        pump.flush()
+        self.clock.pump([0, 0.3])
+        pump.flush()
+        self.failureResultOf(result1, redis.TimeoutError)
+        self.failureResultOf(result2, redis.ConnectionError)

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -98,13 +98,6 @@ class FakeRedisFactory(Factory):
 
     role = ["master", 0, ["127.0.0.1", 63791, 0]]
 
-    convertNumbers = True
-    password = None
-    dbid = None
-
-    def addConnection(self, conn): pass
-    def delConnection(self, conn): pass
-
 
 class FakeAuthenticatedRedisFactory(FakeRedisFactory):
     def __init__(self, requirepass):

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -10,6 +10,9 @@ from txredisapi import BaseRedisProtocol, Sentinel, MasterNotFoundError
 class FakeRedisProtocol(BaseRedisProtocol):
     @classmethod
     def _encode_value(cls, value):
+        if value is None:
+            return b'$-1\r\n'
+
         if isinstance(value, (list, tuple)):
             parts = [b'*', str(len(value)).encode('ascii'), b'\r\n']
             parts.extend(cls._encode_value(x) for x in value)

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -599,7 +599,8 @@ class BaseRedisProtocol(LineReceiver):
             response = self.replyQueue.get().addCallback(self.handle_reply)
             response.addBoth(fire_result)
 
-            if self.replyTimeout:
+            apply_timeout = kwargs.get('apply_timeout', True)
+            if self.replyTimeout and apply_timeout:
                 delayed_call = None
 
                 def fire_timeout():
@@ -1031,7 +1032,7 @@ class BaseRedisProtocol(LineReceiver):
             keys = list(keys)
 
         keys.append(timeout)
-        return self.execute_command("BLPOP", *keys)
+        return self.execute_command("BLPOP", *keys, apply_timeout=False)
 
     @_blocking_command(release_on_callback=True)
     def brpop(self, keys, timeout=0):
@@ -1044,7 +1045,7 @@ class BaseRedisProtocol(LineReceiver):
             keys = list(keys)
 
         keys.append(timeout)
-        return self.execute_command("BRPOP", *keys)
+        return self.execute_command("BRPOP", *keys, apply_timeout=False)
 
     @_blocking_command(release_on_callback=True)
     def brpoplpush(self, source, destination, timeout=0):
@@ -1052,7 +1053,7 @@ class BaseRedisProtocol(LineReceiver):
         Pop a value from a list, push it to another list and return
         it; or block until one is available.
         """
-        return self.execute_command("BRPOPLPUSH", source, destination, timeout)
+        return self.execute_command("BRPOPLPUSH", source, destination, timeout, apply_timeout=False)
 
     def rpoplpush(self, srckey, dstkey):
         """

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -621,7 +621,7 @@ class BaseRedisProtocol(LineReceiver):
             # so that we can wait for them in a DeferredList when
             # execute_pipeline is called.
             if self.pipelining:
-                self.pipelined_replies.append(response)
+                self.pipelined_replies.append(result)
 
             if self.inMulti:
                 self.post_proc.append(kwargs.get("post_proc"))
@@ -1894,7 +1894,7 @@ class MonitorProtocol(RedisProtocol):
         self.messageReceived(reply)
 
     def monitor(self):
-        return self.execute_command("MONITOR")
+        return self.execute_command("MONITOR", apply_timeout=False)
 
     def stop(self):
         self.transport.loseConnection()
@@ -1922,7 +1922,7 @@ class SubscriberProtocol(RedisProtocol):
     def subscribe(self, channels):
         if isinstance(channels, six.string_types):
             channels = [channels]
-        return self.execute_command("SUBSCRIBE", *channels)
+        return self.execute_command("SUBSCRIBE", *channels, apply_timeout=False)
 
     def unsubscribe(self, channels):
         if isinstance(channels, six.string_types):
@@ -1932,7 +1932,7 @@ class SubscriberProtocol(RedisProtocol):
     def psubscribe(self, patterns):
         if isinstance(patterns, six.string_types):
             patterns = [patterns]
-        return self.execute_command("PSUBSCRIBE", *patterns)
+        return self.execute_command("PSUBSCRIBE", *patterns, apply_timeout=False)
 
     def punsubscribe(self, patterns):
         if isinstance(patterns, six.string_types):

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -2290,7 +2290,6 @@ class RedisFactory(protocol.ReconnectingClientFactory):
                           convertNumbers=self.convertNumbers)
         p.factory = self
         p.whenConnected().addCallback(self.addConnection)
-        p.whenDisconnected().addCallback(self.delConnection)
         return p
 
     def addConnection(self, conn):
@@ -2298,6 +2297,7 @@ class RedisFactory(protocol.ReconnectingClientFactory):
             conn.transport.loseConnection()
             return
 
+        conn.whenDisconnected().addCallback(self.delConnection)
         self.connectionQueue.put(conn)
         self.pool.append(conn)
         self.size = len(self.pool)

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -604,9 +604,10 @@ class BaseRedisProtocol(LineReceiver):
                 delayed_call = None
 
                 def fire_timeout():
-                    result.errback(TimeoutError(
-                        'Not received Redis response in {0} seconds'.format(self.replyTimeout)
-                    ))
+                    error_text = 'Not received Redis response in {0} seconds'.format(self.replyTimeout)
+                    result.errback(TimeoutError(error_text))
+                    while self.replyQueue.waiting:
+                        self.replyQueue.put(TimeoutError(error_text))
                     self.transport.abortConnection()
 
                 def cancel_timeout(value):


### PR DESCRIPTION
txredisapi has `replyTimeout` connection argument, but it effectively broken and doesn't work at all.

Prior art:
* #100 Fix reply timeout by @jjappi 
* #105 connectTimeout and replyTimeout by @arnimarj

Both mentioned PRs failed to meet following criteria and were closed (see corresponding discussions):
1. Exception should be raised if query waits more than `replyTimeout` seconds.
2. Exception should not be raised if all queries are served in less than `replyTimeout` seconds (including idle connection).

This is the third try to implement `replyTimeout`.

`TimeoutError` is inherited from `ConnectionError` to be compatible with existing client code that may expect `ConnectionError` to be the only exception type that may be raised by query methods.

@jjappi, @arnimarj, I would be happy if you find time to review and test this PR (if you are still interested of course)