### PR TITLE
Fixed handling server replies not related to pub/sub in SubscriberProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Release 1.4.6 (UNRELEASED)
+
+### Bugfixes
+
+- allow any commands to be sent via SubscriberProtocol
+
+---
+
 ## Release 1.4.5 (2017-11-08)
 
 ### Features

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1851,11 +1851,12 @@ class SubscriberProtocol(RedisProtocol):
 
     def replyReceived(self, reply):
         if isinstance(reply, list):
-            if reply[-3] == u"message":
+            reply_len = len(reply)
+            if reply_len >= 3 and reply[-3] == u"message":
                 self.messageReceived(None, *reply[-2:])
-            elif len(reply) > 3 and reply[-4] == u"pmessage":
+            elif reply_len >= 4 and reply[-4] == u"pmessage":
                 self.messageReceived(*reply[-3:])
-            elif reply[-3] in self._sub_unsub_reponses and len(self.replyQueue.waiting) == 0:
+            elif reply_len >= 3 and reply[-3] in self._sub_unsub_reponses and len(self.replyQueue.waiting) == 0:
                 pass
             else:
                 self.replyQueue.put(reply[-3:])


### PR DESCRIPTION
This allows for example sending regular PINGs with SubscriberProtocol. Before this change PONG caused IndexError in `SubscriberProtocol.replyReceived` because `len(reply) == 2` .