### PR TITLE
Properly handle bulk response of command issued right before multi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 - allow any commands to be sent via SubscriberProtocol
 
+- Fixed bug in handling responses from Redis when MULTI is issued right after
+  another bulk command (SMEMBERS for example)
+
 ---
 
 ## Release 1.4.5 (2017-11-08)

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -256,6 +256,7 @@ class BaseRedisProtocol(LineReceiver, policies.TimeoutMixin):
         self.replyQueue = ReplyQueue()
 
         self.transactions = 0
+        self.pendingTransaction = False
         self.inTransaction = False
         self.inMulti = False
         self.unwatch_cc = lambda: ()
@@ -1462,14 +1463,16 @@ class BaseRedisProtocol(LineReceiver, policies.TimeoutMixin):
 
     def _clear_txstate(self):
         if self.inTransaction:
+            self.pendingTransaction = False
             self.inTransaction = False
             self.inMulti = False
             self.factory.connectionQueue.put(self)
 
     @_blocking_command(release_on_callback=False)
     def watch(self, keys):
-        if not self.inTransaction:
-            self.inTransaction = True
+        if not self.pendingTransaction:
+            self.pendingTransaction = True
+            self.inTransaction = False
             self.inMulti = False
             self.unwatch_cc = self._clear_txstate
             self.commit_cc = lambda: ()
@@ -1489,7 +1492,8 @@ class BaseRedisProtocol(LineReceiver, policies.TimeoutMixin):
     # must be executed.
     @_blocking_command(release_on_callback=False)
     def multi(self, keys=None):
-        self.inTransaction = True
+        self.pendingTransaction = True
+        self.inTransaction = False
         self.inMulti = True
         self.unwatch_cc = lambda: ()
         self.commit_cc = self._clear_txstate
@@ -1504,6 +1508,7 @@ class BaseRedisProtocol(LineReceiver, policies.TimeoutMixin):
     def _tx_started(self, response):
         if response != 'OK':
             raise RedisError('Invalid response: %s' % response)
+        self.inTransaction = True
         return self
 
     def _commit_check(self, response):


### PR DESCRIPTION
#136 recreated with changelog entry and updated to master