### PR TITLE
Make __all__ a list of strings

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -2794,15 +2794,15 @@ class Sentinel(object):
 
 
 __all__ = [
-    Connection, lazyConnection,
-    ConnectionPool, lazyConnectionPool,
-    ShardedConnection, lazyShardedConnection,
-    ShardedConnectionPool, lazyShardedConnectionPool,
-    UnixConnection, lazyUnixConnection,
-    UnixConnectionPool, lazyUnixConnectionPool,
-    ShardedUnixConnection, lazyShardedUnixConnection,
-    ShardedUnixConnectionPool, lazyShardedUnixConnectionPool,
-    Sentinel, MasterNotFoundError
+    "Connection", "lazyConnection",
+    "ConnectionPool", "lazyConnectionPool",
+    "ShardedConnection", "lazyShardedConnection",
+    "ShardedConnectionPool", "lazyShardedConnectionPool",
+    "UnixConnection", "lazyUnixConnection",
+    "UnixConnectionPool", "lazyUnixConnectionPool",
+    "ShardedUnixConnection", "lazyShardedUnixConnection",
+    "ShardedUnixConnectionPool", "lazyShardedUnixConnectionPool",
+    "Sentinel", "MasterNotFoundError"
 ]
 
 __author__ = "Alexandre Fiori"


### PR DESCRIPTION
This fixes mypy from producing this error:

```
$ stubgen -m txredisapi
Traceback (most recent call last):
  File ".../.venv/bin/stubgen", line 8, in <module>
    sys.exit(main())
  File "mypy/stubgen.py", line 1564, in main
  File "mypy/stubgen.py", line 1442, in generate_stubs
  File "mypy/stubgen.py", line 1385, in generate_stub_from_ast
  File "mypy/stubgen.py", line 515, in __init__
TypeError: str object expected; got function
```