### PR TITLE
FIX charset=None was causing SubscriberProtocol.messageReceived to ne…

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1908,7 +1908,8 @@ class MonitorProtocol(RedisProtocol):
 
 
 class SubscriberProtocol(RedisProtocol):
-    _sub_unsub_reponses = set([u"subscribe", u"unsubscribe", u"psubscribe", u"punsubscribe"])
+    _sub_unsub_reponses = set([u"subscribe", u"unsubscribe", u"psubscribe", u"punsubscribe",
+                               b"subscribe", b"unsubscribe", b"psubscribe", b"punsubscribe"])
 
     def messageReceived(self, pattern, channel, message):
         pass

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1916,9 +1916,9 @@ class SubscriberProtocol(RedisProtocol):
     def replyReceived(self, reply):
         if isinstance(reply, list):
             reply_len = len(reply)
-            if reply_len >= 3 and reply[-3] == u"message":
+            if reply_len >= 3 and reply[-3] in (u"message", b"message"):
                 self.messageReceived(None, *reply[-2:])
-            elif reply_len >= 4 and reply[-4] == u"pmessage":
+            elif reply_len >= 4 and reply[-4] in (u"pmessage", b"pmessage"):
                 self.messageReceived(*reply[-3:])
             elif reply_len >= 3 and reply[-3] in self._sub_unsub_reponses and len(self.replyQueue.waiting) == 0:
                 pass


### PR DESCRIPTION
This will fix the issue where charset if set to None would cause SubscriberProtocol .messageReceived to never be called

If the charset = None in SubscriberProtocol then SubscriberProtocol .replyReceived will never call SubscriberProtocol.messageReceived due to u"message" when received will not match b"message" and u"pmessage" will not match b"pmessage" inside the if clauses therefore the code where messageReceived is called will never be reached. This is due to types of str and bytes will not match each other even if similar values are inside