### PR TITLE
Use unittest.mock in Python >= 3.3

### DIFF
--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,10 +1,15 @@
 import six
-from mock import Mock
+import sys
 from twisted.internet import defer, reactor
 from twisted.internet.protocol import Factory
 from twisted.trial.unittest import TestCase
 
 from txredisapi import BaseRedisProtocol, Sentinel, MasterNotFoundError
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import Mock
+else:
+    from mock import Mock
 
 
 class FakeRedisProtocol(BaseRedisProtocol):


### PR DESCRIPTION
Since Python 3.3, the `mock` package has been integrated into the Python standard library, and is available as `unittest.mock`.  Use it when testing on new enough Pythons to eliminate unnecessary dependency.