### PR TITLE
Fix INFO command parsing for lines with multiple colons

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1685,7 +1685,7 @@ class BaseRedisProtocol(LineReceiver):
                     ':' in x and not x.startswith('#')]
         d = {}
         for kv in keypairs:
-            k, v = kv.split(':')
+            k, v = kv.split(':', 1)
             d[k] = v
         return d
 


### PR DESCRIPTION
This commit resolves an issue with parsing the `INFO` command output when lines contain multiple `:` characters, such as those with IPv6 addresses:
```
  listener0:name=tcp,bind=127.0.0.1,bind=::1,port=6379
```
Such a line can appear there since the Redis version 7.2.0. Listneres info was introdcued commit 0c4d2fcc8eff ("Add listeners info string for 'INFO' command").

The fix is simple, the split() method in _process_info() is restricted to perform the split only on the first `:` character.

Fixes: https://github.com/IlyaSkriblovsky/txredisapi/issues/151