### PR TITLE
Add support for specifying username for authentication and bump version to 1.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Release 1.4.12 (2026-04-??)
+
+### Features
+
+- Add `username` parameter to all connection functions for Redis 6+ ACL
+  authentication (`AUTH username password`)
+
+### Bugfixes
+
+- Fix `RedisFactory.buildProtocol` not passing `username` to the protocol
+  constructor, causing username-based auth to be silently ignored
+
+### Documentation
+
+- Correct connection function signatures in README (previously omitted
+  `ssl_context_factory`, `connectTimeout`, `replyTimeout`, `convertNumbers`)
+- Add strong recommendation to use keyword arguments due to the number of
+  parameters and risk of silent misconfiguration with positional usage
+- Fix test invocation command (`python -m twisted.trial tests`)
+
+---
 ## Release 1.4.11 (2025-04-11)
 
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ However, if you really really insist in installing, get it from pypi:
 ### Unit Tests ###
 
 [Twisted Trial](http://twistedmatrix.com/trac/wiki/TwistedTrial) unit tests
-are available. Just start redis, and run ``trial ./tests``.
+are available. Start redis, then run:
+
+    python -m twisted.trial tests
+
 If *unix sockets* are disabled in redis, it will silently skip those tests.
 
 Make sure you run `redis-cli flushall` to clean up redis after the tests.
@@ -116,30 +119,73 @@ with absolutely no changes to the logic of your program.
 
 These are all the supported methods for connecting to Redis::
 
-    Connection(host, port, dbid, reconnect, charset)
-    lazyConnection(host, port, dbid, reconnect, charset)
+    Connection(host, port, dbid, reconnect, charset, password,
+               ssl_context_factory, connectTimeout, replyTimeout,
+               convertNumbers, username)
+    lazyConnection(host, port, dbid, reconnect, charset, password,
+                   ssl_context_factory, connectTimeout, replyTimeout,
+                   convertNumbers, username)
 
-    ConnectionPool(host, port, dbid, poolsize, reconnect, charset)
-    lazyConnectionPool(host, port, dbid, poolsize, reconnect, charset)
+    ConnectionPool(host, port, dbid, poolsize, reconnect, charset,
+                   password, ssl_context_factory, connectTimeout,
+                   replyTimeout, convertNumbers, username)
+    lazyConnectionPool(host, port, dbid, poolsize, reconnect,
+                       charset, password, ssl_context_factory,
+                       connectTimeout, replyTimeout, convertNumbers,
+                       username)
 
-    ShardedConnection(hosts, dbid, reconnect, charset)
-    lazyShardedConnection(hosts, dbid, reconnect, charset)
+    ShardedConnection(hosts, dbid, reconnect, charset, password,
+                      ssl_context_factory, connectTimeout, replyTimeout,
+                      convertNumbers, username)
+    lazyShardedConnection(hosts, dbid, reconnect, charset, password,
+                          ssl_context_factory, connectTimeout,
+                          replyTimeout, convertNumbers, username)
 
-    ShardedConnectionPool(hosts, dbid, poolsize, reconnect, charset)
-    lazyShardedConnectionPool(hosts, dbid, poolsize, reconnect, charset)
+    ShardedConnectionPool(hosts, dbid, poolsize, reconnect, charset,
+                          password, ssl_context_factory, connectTimeout,
+                          replyTimeout, convertNumbers, username)
+    lazyShardedConnectionPool(hosts, dbid, poolsize, reconnect,
+                              charset, password, ssl_context_factory,
+                              connectTimeout, replyTimeout,
+                              convertNumbers, username)
 
-    UnixConnection(path, dbid, reconnect, charset)
-    lazyUnixConnection(path, dbid, reconnect, charset)
+    UnixConnection(path, dbid, reconnect, charset, password,
+                   connectTimeout, replyTimeout, convertNumbers,
+                   username)
+    lazyUnixConnection(path, dbid, reconnect, charset, password,
+                       connectTimeout, replyTimeout, convertNumbers,
+                       username)
 
-    UnixConnectionPool(unix, dbid, poolsize, reconnect, charset)
-    lazyUnixConnectionPool(unix, dbid, poolsize, reconnect, charset)
+    UnixConnectionPool(path, dbid, poolsize, reconnect, charset,
+                       password, connectTimeout, replyTimeout,
+                       convertNumbers, username)
+    lazyUnixConnectionPool(path, dbid, poolsize, reconnect, charset,
+                           password, connectTimeout, replyTimeout,
+                           convertNumbers, username)
 
-    ShardedUnixConnection(paths, dbid, reconnect, charset)
-    lazyShardedUnixConnection(paths, dbid, reconnect, charset)
+    ShardedUnixConnection(paths, dbid, reconnect, charset, password,
+                          connectTimeout, replyTimeout, convertNumbers,
+                          username)
+    lazyShardedUnixConnection(paths, dbid, reconnect, charset,
+                              password, connectTimeout, replyTimeout,
+                              convertNumbers, username)
 
-    ShardedUnixConnectionPool(paths, dbid, poolsize, reconnect, charset)
-    lazyShardedUnixConnectionPool(paths, dbid, poolsize, reconnect, charset)
+    ShardedUnixConnectionPool(paths, dbid, poolsize, reconnect,
+                              charset, password, connectTimeout,
+                              replyTimeout, convertNumbers, username)
+    lazyShardedUnixConnectionPool(paths, dbid, poolsize, reconnect,
+                                  charset, password, connectTimeout,
+                                  replyTimeout, convertNumbers, username)
 
+> **Note:** Given the number of parameters and the fact that new ones may be
+> added in the future, **passing arguments as keyword arguments is strongly
+> encouraged**. Positional usage is fragile — a new parameter inserted
+> anywhere before `username` or `password` will silently shift your values
+> onto the wrong argument. Always prefer:
+>
+>     redis.Connection(host="localhost", password="secret", username="myuser")
+>
+> over positional form.
 
 The arguments are:
 
@@ -154,7 +200,11 @@ The arguments are:
 - hosts (for sharded): list of ``host:port`` pairs. [default: None]
 - paths (for sharded): list of ``pathnames``. [default: None]
 - password: password for the redis server. [default: None]
-- ssl_context_factory: Either a boolean indicating wether to use SSL/TLS or a specific `ClientContextFactory`. [default: False]
+- username: username for the redis server (Redis 6+ ACL). [default: None]
+- ssl_context_factory: Either a boolean indicating whether to use SSL/TLS or a specific `ClientContextFactory`. Not available for Unix socket connections. [default: False]
+- connectTimeout: timeout in seconds for establishing the connection. [default: None]
+- replyTimeout: timeout in seconds for waiting for a reply. [default: None]
+- convertNumbers: automatically convert numeric replies to Python int/float. [default: True]
 
 
 ### Connection Handlers ###
@@ -619,6 +669,10 @@ This is how to authenticate::
     if __name__ == "__main__":
         main()
         reactor.run()
+
+For Redis 6+ ACL-based authentication, specify both ``username`` and ``password``::
+
+    redis = yield txredisapi.Connection(username="myuser", password="foobared")
         
 ### Connection using Redis Sentinel ###
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setuptools.setup(
     name="txredisapi",
-    version="1.4.11",
+    version="1.4.12",
     py_modules=["txredisapi"],
     install_requires=["twisted", "six"],
     author="Alexandre Fiori",

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -249,7 +249,7 @@ class BaseRedisProtocol(LineReceiver):
     """
 
     def __init__(self, charset="utf-8", errors="strict", replyTimeout=None,
-                 password=None, dbid=None, convertNumbers=True):
+                 password=None, dbid=None, convertNumbers=True, username=None):
         self.charset = charset
         self.errors = errors
 
@@ -275,6 +275,8 @@ class BaseRedisProtocol(LineReceiver):
         self.pipelined_replies = []
 
         self.replyTimeout = replyTimeout
+        # Username is the last init parameter for backward compatibility
+        self.username = username
         self.password = password
         self.dbid = dbid
         self.convertNumbers = convertNumbers
@@ -299,7 +301,7 @@ class BaseRedisProtocol(LineReceiver):
     def connectionMade(self):
         if self.password is not None:
             try:
-                response = yield self.auth(self.password)
+                response = yield self.auth(self.password, self.username)
                 if isinstance(response, ResponseError):
                     raise response
             except Exception as e:
@@ -647,10 +649,13 @@ class BaseRedisProtocol(LineReceiver):
         self.factory.continueTrying = False
         return self.execute_command("QUIT")
 
-    def auth(self, password):
+    def auth(self, password, username = None):
         """
-        Simple password authentication if enabled
+        Simple password authentication if enabled. Username is specified
+        last for backward compatibility.
         """
+        if username:
+            return self.execute_command('AUTH', username, password)
         return self.execute_command("AUTH", password)
 
     def ping(self):
@@ -2266,7 +2271,7 @@ class RedisFactory(protocol.ReconnectingClientFactory):
 
     def __init__(self, uuid, dbid, poolsize, isLazy=False,
                  handler=ConnectionHandler, charset="utf-8", password=None,
-                 replyTimeout=None, convertNumbers=True):
+                 replyTimeout=None, convertNumbers=True, username=None):
         if not isinstance(poolsize, int):
             raise ValueError("Redis poolsize must be an integer, not %s" %
                              repr(poolsize))
@@ -2280,6 +2285,7 @@ class RedisFactory(protocol.ReconnectingClientFactory):
         self.poolsize = poolsize
         self.isLazy = isLazy
         self.charset = charset
+        self.username = username
         self.password = password
         self.replyTimeout = replyTimeout
         self.convertNumbers = convertNumbers
@@ -2296,7 +2302,8 @@ class RedisFactory(protocol.ReconnectingClientFactory):
     def buildProtocol(self, addr):
         p = self.protocol(self.charset, replyTimeout=self.replyTimeout,
                           password=self.password, dbid=self.dbid,
-                          convertNumbers=self.convertNumbers)
+                          convertNumbers=self.convertNumbers,
+                          username=self.username)
         p.factory = self
         p.whenConnected().addCallback(self.addConnection)
         return p
@@ -2383,10 +2390,11 @@ class MonitorFactory(RedisFactory):
 
 def makeConnection(host, port, dbid, poolsize, reconnect, isLazy,
                    charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                   convertNumbers):
+                   convertNumbers, username=None):
     uuid = "%s:%d" % (host, port)
     factory = RedisFactory(uuid, dbid, poolsize, isLazy, ConnectionHandler,
-                           charset, password, replyTimeout, convertNumbers)
+                           charset, password, replyTimeout, convertNumbers,
+                           username)
     factory.continueTrying = reconnect
     for x in range(poolsize):
         if ssl_context_factory is True:
@@ -2404,7 +2412,7 @@ def makeConnection(host, port, dbid, poolsize, reconnect, isLazy,
 
 def makeShardedConnection(hosts, dbid, poolsize, reconnect, isLazy,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers):
+                          convertNumbers, username=None):
     err = "Please use a list or tuple of host:port for sharded connections"
     if not isinstance(hosts, (list, tuple)):
         raise ValueError(err)
@@ -2419,7 +2427,7 @@ def makeShardedConnection(hosts, dbid, poolsize, reconnect, isLazy,
 
         c = makeConnection(host, port, dbid, poolsize, reconnect, isLazy,
                            charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                           convertNumbers)
+                           convertNumbers, username)
         connections.append(c)
 
     if isLazy:
@@ -2432,78 +2440,80 @@ def makeShardedConnection(hosts, dbid, poolsize, reconnect, isLazy,
 
 def Connection(host="localhost", port=6379, dbid=None, reconnect=True,
                charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
-               connectTimeout=None, replyTimeout=None, convertNumbers=True):
+               connectTimeout=None, replyTimeout=None, convertNumbers=True, username=None):
     return makeConnection(host, port, dbid, 1, reconnect, False,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers)
+                          convertNumbers, username)
 
 
 def lazyConnection(host="localhost", port=6379, dbid=None, reconnect=True,
                    charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
-                   connectTimeout=None, replyTimeout=None, convertNumbers=True):
+                   connectTimeout=None, replyTimeout=None, convertNumbers=True,
+                   username=None):
     return makeConnection(host, port, dbid, 1, reconnect, True,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers)
+                          convertNumbers, username)
 
 
 def ConnectionPool(host="localhost", port=6379, dbid=None,
                    poolsize=10, reconnect=True, charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
                    connectTimeout=None, replyTimeout=None,
-                   convertNumbers=True):
+                   convertNumbers=True, username=None):
     return makeConnection(host, port, dbid, poolsize, reconnect, False,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers)
+                          convertNumbers, username)
 
 
 def lazyConnectionPool(host="localhost", port=6379, dbid=None,
                        poolsize=10, reconnect=True, charset="utf-8",
                        password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False, connectTimeout=None, replyTimeout=None,
-                       convertNumbers=True):
+                       convertNumbers=True, username=None):
     return makeConnection(host, port, dbid, poolsize, reconnect, True,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers)
+                          convertNumbers, username)
 
 
 def ShardedConnection(hosts, dbid=None, reconnect=True, charset="utf-8",
                       password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False, connectTimeout=None, replyTimeout=None,
-                      convertNumbers=True):
+                      convertNumbers=True, username=None):
     return makeShardedConnection(hosts, dbid, 1, reconnect, False,
                                  charset, password, ssl_context_factory, connectTimeout,
-                                 replyTimeout, convertNumbers)
+                                 replyTimeout, convertNumbers, username)
 
 
 def lazyShardedConnection(hosts, dbid=None, reconnect=True, charset="utf-8",
                           password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
                           connectTimeout=None, replyTimeout=None,
-                          convertNumbers=True):
+                          convertNumbers=True, username=None):
     return makeShardedConnection(hosts, dbid, 1, reconnect, True,
                                  charset, password, ssl_context_factory, connectTimeout,
-                                 replyTimeout, convertNumbers)
+                                 replyTimeout, convertNumbers, username)
 
 
 def ShardedConnectionPool(hosts, dbid=None, poolsize=10, reconnect=True,
                           charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
                           connectTimeout=None, replyTimeout=None,
-                          convertNumbers=True):
+                          convertNumbers=True, username=None):
     return makeShardedConnection(hosts, dbid, poolsize, reconnect, False,
                                  charset, password, ssl_context_factory, connectTimeout,
-                                 replyTimeout, convertNumbers)
+                                 replyTimeout, convertNumbers, username)
 
 
 def lazyShardedConnectionPool(hosts, dbid=None, poolsize=10, reconnect=True,
                               charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
                               connectTimeout=None, replyTimeout=None,
-                              convertNumbers=True):
+                              convertNumbers=True, username=None):
     return makeShardedConnection(hosts, dbid, poolsize, reconnect, True,
                                  charset, password, ssl_context_factory, connectTimeout,
-                                 replyTimeout, convertNumbers)
+                                 replyTimeout, convertNumbers, username)
 
 
 def makeUnixConnection(path, dbid, poolsize, reconnect, isLazy,
                        charset, password, connectTimeout, replyTimeout,
-                       convertNumbers):
+                       convertNumbers, username=None):
     factory = RedisFactory(path, dbid, poolsize, isLazy, UnixConnectionHandler,
-                           charset, password, replyTimeout, convertNumbers)
+                           charset, password, replyTimeout, convertNumbers,
+                           username)
     factory.continueTrying = reconnect
     for x in range(poolsize):
         reactor.connectUNIX(path, factory, connectTimeout)
@@ -2516,7 +2526,7 @@ def makeUnixConnection(path, dbid, poolsize, reconnect, isLazy,
 
 def makeShardedUnixConnection(paths, dbid, poolsize, reconnect, isLazy,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers):
+                              convertNumbers, username=None):
     err = "Please use a list or tuple of paths for sharded unix connections"
     if not isinstance(paths, (list, tuple)):
         raise ValueError(err)
@@ -2525,7 +2535,7 @@ def makeShardedUnixConnection(paths, dbid, poolsize, reconnect, isLazy,
     for path in paths:
         c = makeUnixConnection(path, dbid, poolsize, reconnect, isLazy,
                                charset, password, connectTimeout, replyTimeout,
-                               convertNumbers)
+                               convertNumbers, username)
         connections.append(c)
 
     if isLazy:
@@ -2538,72 +2548,74 @@ def makeShardedUnixConnection(paths, dbid, poolsize, reconnect, isLazy,
 
 def UnixConnection(path="/tmp/redis.sock", dbid=None, reconnect=True,
                    charset="utf-8", password=None,
-                   connectTimeout=None, replyTimeout=None, convertNumbers=True):
+                   connectTimeout=None, replyTimeout=None, convertNumbers=True,
+                   username=None):
     return makeUnixConnection(path, dbid, 1, reconnect, False,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers)
+                              convertNumbers, username)
 
 
 def lazyUnixConnection(path="/tmp/redis.sock", dbid=None, reconnect=True,
                        charset="utf-8", password=None,
                        connectTimeout=None, replyTimeout=None,
-                       convertNumbers=True):
+                       convertNumbers=True, username=None):
     return makeUnixConnection(path, dbid, 1, reconnect, True,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers)
+                              convertNumbers, username)
 
 
 def UnixConnectionPool(path="/tmp/redis.sock", dbid=None, poolsize=10,
                        reconnect=True, charset="utf-8", password=None,
                        connectTimeout=None, replyTimeout=None,
-                       convertNumbers=True):
+                       convertNumbers=True, username=None):
     return makeUnixConnection(path, dbid, poolsize, reconnect, False,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers)
+                              convertNumbers, username)
 
 
 def lazyUnixConnectionPool(path="/tmp/redis.sock", dbid=None, poolsize=10,
                            reconnect=True, charset="utf-8", password=None,
                            connectTimeout=None, replyTimeout=None,
-                           convertNumbers=True):
+                           convertNumbers=True, username=None):
     return makeUnixConnection(path, dbid, poolsize, reconnect, True,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers)
+                              convertNumbers, username)
 
 
 def ShardedUnixConnection(paths, dbid=None, reconnect=True, charset="utf-8",
                           password=None, connectTimeout=None, replyTimeout=None,
-                          convertNumbers=True):
+                          convertNumbers=True, username=None):
     return makeShardedUnixConnection(paths, dbid, 1, reconnect, False,
                                      charset, password, connectTimeout,
-                                     replyTimeout, convertNumbers)
+                                     replyTimeout, convertNumbers, username)
 
 
 def lazyShardedUnixConnection(paths, dbid=None, reconnect=True,
                               charset="utf-8", password=None,
                               connectTimeout=None, replyTimeout=None,
-                              convertNumbers=True):
+                              convertNumbers=True, username=None):
     return makeShardedUnixConnection(paths, dbid, 1, reconnect, True,
                                      charset, password, connectTimeout,
-                                     replyTimeout, convertNumbers)
+                                     replyTimeout, convertNumbers, username)
 
 
 def ShardedUnixConnectionPool(paths, dbid=None, poolsize=10, reconnect=True,
                               charset="utf-8", password=None,
                               connectTimeout=None, replyTimeout=None,
-                              convertNumbers=True):
+                              convertNumbers=True, username=None):
     return makeShardedUnixConnection(paths, dbid, poolsize, reconnect, False,
                                      charset, password, connectTimeout,
-                                     replyTimeout, convertNumbers)
+                                     replyTimeout, convertNumbers, username)
 
 
 def lazyShardedUnixConnectionPool(paths, dbid=None, poolsize=10,
                                   reconnect=True, charset="utf-8",
                                   password=None, connectTimeout=None,
-                                  replyTimeout=None, convertNumbers=True):
+                                  replyTimeout=None, convertNumbers=True,
+                                  username=None):
     return makeShardedUnixConnection(paths, dbid, poolsize, reconnect, True,
                                      charset, password, connectTimeout,
-                                     replyTimeout, convertNumbers)
+                                     replyTimeout, convertNumbers, username)
 
 
 class MasterNotFoundError(ConnectionError):
@@ -2813,4 +2825,4 @@ __all__ = [
 ]
 
 __author__ = "Alexandre Fiori"
-__version__ = version = "1.4.11"
+__version__ = version = "1.4.12"

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -249,7 +249,7 @@ class BaseRedisProtocol(LineReceiver):
     """
 
     def __init__(self, charset="utf-8", errors="strict", replyTimeout=None,
-                 password=None, dbid=None, convertNumbers=True):
+                 password=None, dbid=None, convertNumbers=True, username=None):
         self.charset = charset
         self.errors = errors
 
@@ -275,6 +275,8 @@ class BaseRedisProtocol(LineReceiver):
         self.pipelined_replies = []
 
         self.replyTimeout = replyTimeout
+        # Username is the last init parameter for backward compatibility
+        self.username = username
         self.password = password
         self.dbid = dbid
         self.convertNumbers = convertNumbers
@@ -299,7 +301,7 @@ class BaseRedisProtocol(LineReceiver):
     def connectionMade(self):
         if self.password is not None:
             try:
-                response = yield self.auth(self.password)
+                response = yield self.auth(self.password, self.username)
                 if isinstance(response, ResponseError):
                     raise response
             except Exception as e:
@@ -647,10 +649,13 @@ class BaseRedisProtocol(LineReceiver):
         self.factory.continueTrying = False
         return self.execute_command("QUIT")
 
-    def auth(self, password):
+    def auth(self, password, username=None):
         """
-        Simple password authentication if enabled
+        Simple password authentication if enabled. Username is specified
+        last for backward compatibility.
         """
+        if username:
+            return self.execute_command('AUTH', username, password)
         return self.execute_command("AUTH", password)
 
     def ping(self):
@@ -2266,7 +2271,7 @@ class RedisFactory(protocol.ReconnectingClientFactory):
 
     def __init__(self, uuid, dbid, poolsize, isLazy=False,
                  handler=ConnectionHandler, charset="utf-8", password=None,
-                 replyTimeout=None, convertNumbers=True):
+                 replyTimeout=None, convertNumbers=True, username=None):
         if not isinstance(poolsize, int):
             raise ValueError("Redis poolsize must be an integer, not %s" %
                              repr(poolsize))
@@ -2280,6 +2285,7 @@ class RedisFactory(protocol.ReconnectingClientFactory):
         self.poolsize = poolsize
         self.isLazy = isLazy
         self.charset = charset
+        self.username = username
         self.password = password
         self.replyTimeout = replyTimeout
         self.convertNumbers = convertNumbers
@@ -2296,7 +2302,8 @@ class RedisFactory(protocol.ReconnectingClientFactory):
     def buildProtocol(self, addr):
         p = self.protocol(self.charset, replyTimeout=self.replyTimeout,
                           password=self.password, dbid=self.dbid,
-                          convertNumbers=self.convertNumbers)
+                          convertNumbers=self.convertNumbers,
+                          username=self.username)
         p.factory = self
         p.whenConnected().addCallback(self.addConnection)
         return p
@@ -2383,10 +2390,11 @@ class MonitorFactory(RedisFactory):
 
 def makeConnection(host, port, dbid, poolsize, reconnect, isLazy,
                    charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                   convertNumbers):
+                   convertNumbers, username=None):
     uuid = "%s:%d" % (host, port)
     factory = RedisFactory(uuid, dbid, poolsize, isLazy, ConnectionHandler,
-                           charset, password, replyTimeout, convertNumbers)
+                           charset, password, replyTimeout, convertNumbers,
+                           username)
     factory.continueTrying = reconnect
     for x in range(poolsize):
         if ssl_context_factory is True:
@@ -2404,7 +2412,7 @@ def makeConnection(host, port, dbid, poolsize, reconnect, isLazy,
 
 def makeShardedConnection(hosts, dbid, poolsize, reconnect, isLazy,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers):
+                          convertNumbers, username=None):
     err = "Please use a list or tuple of host:port for sharded connections"
     if not isinstance(hosts, (list, tuple)):
         raise ValueError(err)
@@ -2419,7 +2427,7 @@ def makeShardedConnection(hosts, dbid, poolsize, reconnect, isLazy,
 
         c = makeConnection(host, port, dbid, poolsize, reconnect, isLazy,
                            charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                           convertNumbers)
+                           convertNumbers, username)
         connections.append(c)
 
     if isLazy:
@@ -2432,78 +2440,80 @@ def makeShardedConnection(hosts, dbid, poolsize, reconnect, isLazy,
 
 def Connection(host="localhost", port=6379, dbid=None, reconnect=True,
                charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
-               connectTimeout=None, replyTimeout=None, convertNumbers=True):
+               connectTimeout=None, replyTimeout=None, convertNumbers=True, username=None):
     return makeConnection(host, port, dbid, 1, reconnect, False,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers)
+                          convertNumbers, username)
 
 
 def lazyConnection(host="localhost", port=6379, dbid=None, reconnect=True,
                    charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
-                   connectTimeout=None, replyTimeout=None, convertNumbers=True):
+                   connectTimeout=None, replyTimeout=None, convertNumbers=True,
+                   username=None):
     return makeConnection(host, port, dbid, 1, reconnect, True,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers)
+                          convertNumbers, username)
 
 
 def ConnectionPool(host="localhost", port=6379, dbid=None,
                    poolsize=10, reconnect=True, charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
                    connectTimeout=None, replyTimeout=None,
-                   convertNumbers=True):
+                   convertNumbers=True, username=None):
     return makeConnection(host, port, dbid, poolsize, reconnect, False,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers)
+                          convertNumbers, username)
 
 
 def lazyConnectionPool(host="localhost", port=6379, dbid=None,
                        poolsize=10, reconnect=True, charset="utf-8",
                        password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False, connectTimeout=None, replyTimeout=None,
-                       convertNumbers=True):
+                       convertNumbers=True, username=None):
     return makeConnection(host, port, dbid, poolsize, reconnect, True,
                           charset, password, ssl_context_factory, connectTimeout, replyTimeout,
-                          convertNumbers)
+                          convertNumbers, username)
 
 
 def ShardedConnection(hosts, dbid=None, reconnect=True, charset="utf-8",
                       password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False, connectTimeout=None, replyTimeout=None,
-                      convertNumbers=True):
+                      convertNumbers=True, username=None):
     return makeShardedConnection(hosts, dbid, 1, reconnect, False,
                                  charset, password, ssl_context_factory, connectTimeout,
-                                 replyTimeout, convertNumbers)
+                                 replyTimeout, convertNumbers, username)
 
 
 def lazyShardedConnection(hosts, dbid=None, reconnect=True, charset="utf-8",
                           password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
                           connectTimeout=None, replyTimeout=None,
-                          convertNumbers=True):
+                          convertNumbers=True, username=None):
     return makeShardedConnection(hosts, dbid, 1, reconnect, True,
                                  charset, password, ssl_context_factory, connectTimeout,
-                                 replyTimeout, convertNumbers)
+                                 replyTimeout, convertNumbers, username)
 
 
 def ShardedConnectionPool(hosts, dbid=None, poolsize=10, reconnect=True,
                           charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
                           connectTimeout=None, replyTimeout=None,
-                          convertNumbers=True):
+                          convertNumbers=True, username=None):
     return makeShardedConnection(hosts, dbid, poolsize, reconnect, False,
                                  charset, password, ssl_context_factory, connectTimeout,
-                                 replyTimeout, convertNumbers)
+                                 replyTimeout, convertNumbers, username)
 
 
 def lazyShardedConnectionPool(hosts, dbid=None, poolsize=10, reconnect=True,
                               charset="utf-8", password=None, ssl_context_factory: Union[ssl.ClientContextFactory, bool]=False,
                               connectTimeout=None, replyTimeout=None,
-                              convertNumbers=True):
+                              convertNumbers=True, username=None):
     return makeShardedConnection(hosts, dbid, poolsize, reconnect, True,
                                  charset, password, ssl_context_factory, connectTimeout,
-                                 replyTimeout, convertNumbers)
+                                 replyTimeout, convertNumbers, username)
 
 
 def makeUnixConnection(path, dbid, poolsize, reconnect, isLazy,
                        charset, password, connectTimeout, replyTimeout,
-                       convertNumbers):
+                       convertNumbers, username=None):
     factory = RedisFactory(path, dbid, poolsize, isLazy, UnixConnectionHandler,
-                           charset, password, replyTimeout, convertNumbers)
+                           charset, password, replyTimeout, convertNumbers,
+                           username)
     factory.continueTrying = reconnect
     for x in range(poolsize):
         reactor.connectUNIX(path, factory, connectTimeout)
@@ -2516,7 +2526,7 @@ def makeUnixConnection(path, dbid, poolsize, reconnect, isLazy,
 
 def makeShardedUnixConnection(paths, dbid, poolsize, reconnect, isLazy,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers):
+                              convertNumbers, username=None):
     err = "Please use a list or tuple of paths for sharded unix connections"
     if not isinstance(paths, (list, tuple)):
         raise ValueError(err)
@@ -2525,7 +2535,7 @@ def makeShardedUnixConnection(paths, dbid, poolsize, reconnect, isLazy,
     for path in paths:
         c = makeUnixConnection(path, dbid, poolsize, reconnect, isLazy,
                                charset, password, connectTimeout, replyTimeout,
-                               convertNumbers)
+                               convertNumbers, username)
         connections.append(c)
 
     if isLazy:
@@ -2538,72 +2548,74 @@ def makeShardedUnixConnection(paths, dbid, poolsize, reconnect, isLazy,
 
 def UnixConnection(path="/tmp/redis.sock", dbid=None, reconnect=True,
                    charset="utf-8", password=None,
-                   connectTimeout=None, replyTimeout=None, convertNumbers=True):
+                   connectTimeout=None, replyTimeout=None, convertNumbers=True,
+                   username=None):
     return makeUnixConnection(path, dbid, 1, reconnect, False,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers)
+                              convertNumbers, username)
 
 
 def lazyUnixConnection(path="/tmp/redis.sock", dbid=None, reconnect=True,
                        charset="utf-8", password=None,
                        connectTimeout=None, replyTimeout=None,
-                       convertNumbers=True):
+                       convertNumbers=True, username=None):
     return makeUnixConnection(path, dbid, 1, reconnect, True,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers)
+                              convertNumbers, username)
 
 
 def UnixConnectionPool(path="/tmp/redis.sock", dbid=None, poolsize=10,
                        reconnect=True, charset="utf-8", password=None,
                        connectTimeout=None, replyTimeout=None,
-                       convertNumbers=True):
+                       convertNumbers=True, username=None):
     return makeUnixConnection(path, dbid, poolsize, reconnect, False,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers)
+                              convertNumbers, username)
 
 
 def lazyUnixConnectionPool(path="/tmp/redis.sock", dbid=None, poolsize=10,
                            reconnect=True, charset="utf-8", password=None,
                            connectTimeout=None, replyTimeout=None,
-                           convertNumbers=True):
+                           convertNumbers=True, username=None):
     return makeUnixConnection(path, dbid, poolsize, reconnect, True,
                               charset, password, connectTimeout, replyTimeout,
-                              convertNumbers)
+                              convertNumbers, username)
 
 
 def ShardedUnixConnection(paths, dbid=None, reconnect=True, charset="utf-8",
                           password=None, connectTimeout=None, replyTimeout=None,
-                          convertNumbers=True):
+                          convertNumbers=True, username=None):
     return makeShardedUnixConnection(paths, dbid, 1, reconnect, False,
                                      charset, password, connectTimeout,
-                                     replyTimeout, convertNumbers)
+                                     replyTimeout, convertNumbers, username)
 
 
 def lazyShardedUnixConnection(paths, dbid=None, reconnect=True,
                               charset="utf-8", password=None,
                               connectTimeout=None, replyTimeout=None,
-                              convertNumbers=True):
+                              convertNumbers=True, username=None):
     return makeShardedUnixConnection(paths, dbid, 1, reconnect, True,
                                      charset, password, connectTimeout,
-                                     replyTimeout, convertNumbers)
+                                     replyTimeout, convertNumbers, username)
 
 
 def ShardedUnixConnectionPool(paths, dbid=None, poolsize=10, reconnect=True,
                               charset="utf-8", password=None,
                               connectTimeout=None, replyTimeout=None,
-                              convertNumbers=True):
+                              convertNumbers=True, username=None):
     return makeShardedUnixConnection(paths, dbid, poolsize, reconnect, False,
                                      charset, password, connectTimeout,
-                                     replyTimeout, convertNumbers)
+                                     replyTimeout, convertNumbers, username)
 
 
 def lazyShardedUnixConnectionPool(paths, dbid=None, poolsize=10,
                                   reconnect=True, charset="utf-8",
                                   password=None, connectTimeout=None,
-                                  replyTimeout=None, convertNumbers=True):
+                                  replyTimeout=None, convertNumbers=True,
+                                  username=None):
     return makeShardedUnixConnection(paths, dbid, poolsize, reconnect, True,
                                      charset, password, connectTimeout,
-                                     replyTimeout, convertNumbers)
+                                     replyTimeout, convertNumbers, username)
 
 
 class MasterNotFoundError(ConnectionError):
@@ -2624,7 +2636,7 @@ class SentinelRedisProtocol(RedisProtocol):
                 return RedisProtocol.connectionMade(self)
 
         if self.password is not None:
-            self.auth(self.password)
+            self.auth(self.password, self.username)
 
         return self.role().addCallback(check_role)
 
@@ -2813,4 +2825,4 @@ __all__ = [
 ]
 
 __author__ = "Alexandre Fiori"
-__version__ = version = "1.4.11"
+__version__ = version = "1.4.12"


### PR DESCRIPTION
- Add username support in `BaseRedisProtocol` class
- Update `auth()` method to accept username parameter
- Update changelog with new release 1.4.12
- Bump version from 1.4.11 to 1.4.12 in setup.py
- Update version string in txredisapi.py